### PR TITLE
Introduce a BasePageComponent to deal with analytics, etc.

### DIFF
--- a/components/base-page/index.js
+++ b/components/base-page/index.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+import {logPageView} from '../../utils/ga'
+
+class BasePageComponent extends React.Component {
+  componentDidMount() {
+    logPageView()
+  }
+}
+
+export default BasePageComponent

--- a/components/layouts/main.js
+++ b/components/layouts/main.js
@@ -2,31 +2,19 @@ import PropTypes from 'prop-types'
 import Head from 'next/head'
 import Header from '../header'
 import Footer from '../footer'
-import {logPageView} from '../../utils/ga'
 
-class MainLayout extends React.Component {
-  componentDidMount() {
-    logPageView()
-  }
-  render() {
-    const {children, pageTitle} = this.props
-    return (
-      <div>
-        <Head>
-          <title>{pageTitle}</title>
-          <meta charSet="utf-8" />
-          <meta
-            name="viewport"
-            content="initial-scale=1.0, width=device-width"
-          />
-        </Head>
-        <Header />
-        {children}
-        <Footer />
-      </div>
-    )
-  }
-}
+const MainLayout = ({children, pageTitle}) => (
+  <div>
+    <Head>
+      <title>{pageTitle}</title>
+      <meta charSet="utf-8" />
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+    </Head>
+    <Header />
+    {children}
+    <Footer />
+  </div>
+)
 
 MainLayout.propTypes = {
   children: PropTypes.node.isRequired,

--- a/pages/auth/login.js
+++ b/pages/auth/login.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import BasePageComponent from '../../components/base-page'
 import {graphql, gql, withApollo, compose} from 'react-apollo'
 import cookie from 'cookie'
 
@@ -10,7 +10,7 @@ import redirect from '../../utils/apollo/redirect'
 import checkLoggedIn from '../../utils/apollo/check-logged-in'
 import LoginContent from '../../src/auth/login'
 
-export class Login extends React.Component {
+export class Login extends BasePageComponent {
   /* istanbul ignore next */
   static async getInitialProps(context, apolloClient) {
     const {loggedInUser} = await checkLoggedIn(apolloClient)

--- a/pages/auth/sign-up.js
+++ b/pages/auth/sign-up.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import BasePageComponent from '../../components/base-page'
 import {graphql, gql, withApollo, compose} from 'react-apollo'
 import cookie from 'cookie'
 
@@ -10,7 +10,7 @@ import redirect from '../../utils/apollo/redirect'
 import checkLoggedIn from '../../utils/apollo/check-logged-in'
 import SignUpContent from '../../src/auth/sign-up'
 
-export class SignUp extends React.Component {
+export class SignUp extends BasePageComponent {
   /* istanbul ignore next */
   static async getInitialProps(context, apolloClient) {
     const {loggedInUser} = await checkLoggedIn(apolloClient)

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,11 +1,16 @@
+import BasePageComponent from '../components/base-page'
 import withData from '../utils/apollo/with-data'
 import MainLayout from '../components/layouts/main'
 import IndexContent from '../src'
 
-export const Index = props => (
-  <MainLayout>
-    <IndexContent {...props} />
-  </MainLayout>
-)
+export class Index extends BasePageComponent {
+  render() {
+    return (
+      <MainLayout>
+        <IndexContent {...this.props} />
+      </MainLayout>
+    )
+  }
+}
 
 export default withData(Index)

--- a/pages/projects/create.js
+++ b/pages/projects/create.js
@@ -1,11 +1,16 @@
+import BasePageComponent from '../../components/base-page'
 import withAuth from '../../components/with-auth'
 import MainLayout from '../../components/layouts/main'
 import CreateContent from '../../src/projects/create'
 
-export const Create = props => (
-  <MainLayout>
-    <CreateContent {...props} />
-  </MainLayout>
-)
+export class Create extends BasePageComponent {
+  render() {
+    return (
+      <MainLayout>
+        <CreateContent {...this.props} />
+      </MainLayout>
+    )
+  }
+}
 
 export default withAuth(Create)

--- a/pages/projects/details.js
+++ b/pages/projects/details.js
@@ -1,11 +1,16 @@
+import BasePageComponent from '../../components/base-page'
 import withAuth from '../../components/with-auth'
 import MainLayout from '../../components/layouts/main'
 import DetailsContent from '../../src/projects/details'
 
-export const Details = props => (
-  <MainLayout>
-    <DetailsContent {...props} />
-  </MainLayout>
-)
+export class Details extends BasePageComponent {
+  render() {
+    return (
+      <MainLayout>
+        <DetailsContent {...this.props} />
+      </MainLayout>
+    )
+  }
+}
 
 export default withAuth(Details)

--- a/pages/welcome.js
+++ b/pages/welcome.js
@@ -1,13 +1,16 @@
-import React from 'react'
-
+import BasePageComponent from '../components/base-page'
 import withAuth from '../components/with-auth'
 import MainLayout from '../components/layouts/main'
 import WelcomeContent from '../src/welcome'
 
-export const Welcome = props => (
-  <MainLayout>
-    <WelcomeContent {...props} />
-  </MainLayout>
-)
+export class Welcome extends BasePageComponent {
+  render() {
+    return (
+      <MainLayout>
+        <WelcomeContent {...this.props} />
+      </MainLayout>
+    )
+  }
+}
 
 export default withAuth(Welcome)


### PR DESCRIPTION
Each page in the `pages` folder now extends `BasePageComponent` located in `components/base-page/index.js`.

Since Next.js doesn't have an app-wide common root, this solution brings us closer to an app-wide root. It currently deals with analytics, but could be extended to also deal with performance monitoring or other common tasks.