### PR TITLE
Enable babel root imports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,37 +4,51 @@
       "presets": "next/babel",
       "plugins": [
         "inline-dotenv",
-        ["styled-components", {
-          "displayName": true,
-          "ssr": true,
-          "preprocess": false
-        }]
+        [
+          "styled-components",
+          {
+            "displayName": true,
+            "ssr": true,
+            "preprocess": false
+          }
+        ]
       ]
     },
     "production": {
       "presets": "next/babel",
       "plugins": [
         "transform-inline-environment-variables",
-        ["styled-components", {
-          "displayName": true,
-          "ssr": true,
-          "preprocess": false
-        }]
+        [
+          "styled-components",
+          {
+            "displayName": true,
+            "ssr": true,
+            "preprocess": false
+          }
+        ]
       ]
     },
     "test": {
-      "presets": [
-        ["env", { "modules": "commonjs" }],
-        "next/babel"
-      ],
+      "presets": [["env", {"modules": "commonjs"}], "next/babel"],
       "plugins": [
         "inline-dotenv",
-        ["styled-components", {
-          "displayName": true,
-          "ssr": true,
-          "preprocess": false
-        }]
+        [
+          "styled-components",
+          {
+            "displayName": true,
+            "ssr": true,
+            "preprocess": false
+          }
+        ]
       ]
     }
-  }
+  },
+  "plugins": [
+    [
+      "babel-plugin-root-import",
+      {
+        "rootPathPrefix": "/"
+      }
+    ]
+  ]
 }

--- a/__tests__/pages/auth/login.js
+++ b/__tests__/pages/auth/login.js
@@ -12,7 +12,7 @@ import {
   _signInSuccess,
   _signInError
 } from '../../../pages/auth/login'
-import MainLayout from '../../../components/layouts/main'
+import MainLayout from '/components/layouts/main'
 import LoginContent from '../../../src/auth/login'
 
 describe('pages/auth/login', () => {

--- a/__tests__/pages/auth/login.js
+++ b/__tests__/pages/auth/login.js
@@ -11,7 +11,7 @@ import {
   _mapApolloDataToProps,
   _signInSuccess,
   _signInError
-} from '../../../pages/auth/login'
+} from '/pages/auth/login'
 import MainLayout from '/components/layouts/main'
 import LoginContent from '/src/auth/login'
 

--- a/__tests__/pages/auth/login.js
+++ b/__tests__/pages/auth/login.js
@@ -13,7 +13,7 @@ import {
   _signInError
 } from '../../../pages/auth/login'
 import MainLayout from '/components/layouts/main'
-import LoginContent from '../../../src/auth/login'
+import LoginContent from '/src/auth/login'
 
 describe('pages/auth/login', () => {
   const defaultProps = {

--- a/__tests__/pages/auth/sign-up.js
+++ b/__tests__/pages/auth/sign-up.js
@@ -11,7 +11,7 @@ import {
   _mapApolloDataToProps,
   _signUpSuccess,
   _signUpError
-} from '../../../pages/auth/sign-up'
+} from '/pages/auth/sign-up'
 import MainLayout from '/components/layouts/main'
 import SignUpContent from '/src/auth/sign-up'
 

--- a/__tests__/pages/auth/sign-up.js
+++ b/__tests__/pages/auth/sign-up.js
@@ -12,7 +12,7 @@ import {
   _signUpSuccess,
   _signUpError
 } from '../../../pages/auth/sign-up'
-import MainLayout from '../../../components/layouts/main'
+import MainLayout from '/components/layouts/main'
 import SignUpContent from '../../../src/auth/sign-up'
 
 describe('pages/auth/sign-up', () => {

--- a/__tests__/pages/auth/sign-up.js
+++ b/__tests__/pages/auth/sign-up.js
@@ -13,7 +13,7 @@ import {
   _signUpError
 } from '../../../pages/auth/sign-up'
 import MainLayout from '/components/layouts/main'
-import SignUpContent from '../../../src/auth/sign-up'
+import SignUpContent from '/src/auth/sign-up'
 
 describe('pages/auth/sign-up', () => {
   const props = {

--- a/__tests__/pages/index.js
+++ b/__tests__/pages/index.js
@@ -3,7 +3,7 @@ jest.mock('../../utils/ga')
 
 import {mount} from 'enzyme'
 
-import {Index} from '../../pages'
+import {Index} from '/pages'
 
 describe('pages/index', () => {
   it(`verifies ${Index.name} renders correctly`, () => {

--- a/__tests__/pages/projects/create.js
+++ b/__tests__/pages/projects/create.js
@@ -4,7 +4,7 @@ import {mountComponentWithApolloProvider} from '../../../utils/test-helper'
 
 import {Create} from '../../../pages/projects/create'
 import MainLayout from '/components/layouts/main'
-import CreateContent from '../../../src/projects/create'
+import CreateContent from '/src/projects/create'
 
 const getMockCurrentResult = () =>
   jest.fn().mockReturnValue({

--- a/__tests__/pages/projects/create.js
+++ b/__tests__/pages/projects/create.js
@@ -3,7 +3,7 @@ jest.mock('../../../utils/ga')
 import {mountComponentWithApolloProvider} from '../../../utils/test-helper'
 
 import {Create} from '../../../pages/projects/create'
-import MainLayout from '../../../components/layouts/main'
+import MainLayout from '/components/layouts/main'
 import CreateContent from '../../../src/projects/create'
 
 const getMockCurrentResult = () =>

--- a/__tests__/pages/projects/create.js
+++ b/__tests__/pages/projects/create.js
@@ -2,7 +2,7 @@
 jest.mock('../../../utils/ga')
 import {mountComponentWithApolloProvider} from '/utils/test-helper'
 
-import {Create} from '../../../pages/projects/create'
+import {Create} from '/pages/projects/create'
 import MainLayout from '/components/layouts/main'
 import CreateContent from '/src/projects/create'
 

--- a/__tests__/pages/projects/create.js
+++ b/__tests__/pages/projects/create.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 jest.mock('../../../utils/ga')
-import {mountComponentWithApolloProvider} from '../../../utils/test-helper'
+import {mountComponentWithApolloProvider} from '/utils/test-helper'
 
 import {Create} from '../../../pages/projects/create'
 import MainLayout from '/components/layouts/main'

--- a/__tests__/pages/projects/details.js
+++ b/__tests__/pages/projects/details.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 jest.mock('../../../utils/ga')
 
-import {mountComponentWithApolloProvider} from '../../../utils/test-helper'
+import {mountComponentWithApolloProvider} from '/utils/test-helper'
 
 import {Details} from '../../../pages/projects/details'
 import MainLayout from '/components/layouts/main'

--- a/__tests__/pages/projects/details.js
+++ b/__tests__/pages/projects/details.js
@@ -3,7 +3,7 @@ jest.mock('../../../utils/ga')
 
 import {mountComponentWithApolloProvider} from '/utils/test-helper'
 
-import {Details} from '../../../pages/projects/details'
+import {Details} from '/pages/projects/details'
 import MainLayout from '/components/layouts/main'
 import DetailsContent from '/src/projects/details'
 

--- a/__tests__/pages/projects/details.js
+++ b/__tests__/pages/projects/details.js
@@ -4,7 +4,7 @@ jest.mock('../../../utils/ga')
 import {mountComponentWithApolloProvider} from '../../../utils/test-helper'
 
 import {Details} from '../../../pages/projects/details'
-import MainLayout from '../../../components/layouts/main'
+import MainLayout from '/components/layouts/main'
 import DetailsContent from '../../../src/projects/details'
 
 const getMockCurrentResult = () =>

--- a/__tests__/pages/projects/details.js
+++ b/__tests__/pages/projects/details.js
@@ -5,7 +5,7 @@ import {mountComponentWithApolloProvider} from '../../../utils/test-helper'
 
 import {Details} from '../../../pages/projects/details'
 import MainLayout from '/components/layouts/main'
-import DetailsContent from '../../../src/projects/details'
+import DetailsContent from '/src/projects/details'
 
 const getMockCurrentResult = () =>
   jest.fn().mockReturnValue({

--- a/__tests__/pages/welcome.js
+++ b/__tests__/pages/welcome.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 jest.mock('../../utils/ga')
 
-import {mountComponentWithApolloProvider} from '../../utils/test-helper'
+import {mountComponentWithApolloProvider} from '/utils/test-helper'
 
 import {Welcome} from '../../pages/welcome'
 

--- a/__tests__/pages/welcome.js
+++ b/__tests__/pages/welcome.js
@@ -3,7 +3,7 @@ jest.mock('../../utils/ga')
 
 import {mountComponentWithApolloProvider} from '/utils/test-helper'
 
-import {Welcome} from '../../pages/welcome'
+import {Welcome} from '/pages/welcome'
 
 const getMockCurrentResult = () =>
   jest.fn().mockReturnValue({

--- a/components/base-page/index.js
+++ b/components/base-page/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import {logPageView} from '../../utils/ga'
+import {logPageView} from '/utils/ga'
 
 class BasePageComponent extends React.Component {
   componentDidMount() {

--- a/components/header/index.js
+++ b/components/header/index.js
@@ -1,6 +1,6 @@
 import Box from '../box'
-import {Link} from '../../utils/routes'
-import {authRoutes, homeRoutes} from '../../utils/routes/routes-definitions'
+import {Link} from '/utils/routes'
+import {authRoutes, homeRoutes} from '/utils/routes/routes-definitions'
 import styled from 'styled-components'
 
 import {colors, typography} from '../../styles/constants'

--- a/components/project/__tests__/list.js
+++ b/components/project/__tests__/list.js
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 import {mount} from 'enzyme'
 
-import {Link} from '../../../utils/routes'
-import {projectRoutes} from '../../../utils/routes/routes-definitions'
+import {Link} from '/utils/routes'
+import {projectRoutes} from '/utils/routes/routes-definitions'
 import ProjectList, {ProjectListThumbnail} from '../list'
 
 describe('components/project/list', () => {

--- a/components/project/create-form.js
+++ b/components/project/create-form.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 
 import Button from '../button'
 
-import Input from '../../components/input'
+import Input from '/components/input'
 
 const CreateForm = ({projectTypes, onSubmit}) => (
   <form onSubmit={onSubmit}>

--- a/components/project/list.js
+++ b/components/project/list.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import {Link} from '../../utils/routes'
-import {projectRoutes} from '../../utils/routes/routes-definitions'
+import {Link} from '/utils/routes'
+import {projectRoutes} from '/utils/routes/routes-definitions'
 import {neutrals, typography} from '../../styles/constants'
 
 import Card from '../card'

--- a/components/with-auth/index.js
+++ b/components/with-auth/index.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types'
 import cookie from 'cookie'
 import {withApollo, compose} from 'react-apollo'
 
-import checkLoggedIn from '../../utils/apollo/check-logged-in'
-import withData from '../../utils/apollo/with-data'
+import checkLoggedIn from '/utils/apollo/check-logged-in'
+import withData from '/utils/apollo/with-data'
 
-import {authRoutes} from '../../utils/routes/routes-definitions'
-import redirect from '../../utils/apollo/redirect'
+import {authRoutes} from '/utils/routes/routes-definitions'
+import redirect from '/utils/apollo/redirect'
 
 export default WrappedComponent => {
   class WithAuth extends React.Component {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@storybook/addon-links": "^3.2.6",
     "@storybook/react": "^3.2.8",
     "babel-eslint": "^8.0.0",
+    "babel-plugin-root-import": "^5.1.0",
     "babel-plugin-styled-components": "^1.2.0",
     "coveralls": "^2.13.1",
     "enzyme": "^2.9.1",

--- a/pages/auth/login.js
+++ b/pages/auth/login.js
@@ -8,7 +8,7 @@ import {homeRoutes} from '../../utils/routes/routes-definitions'
 import withData from '../../utils/apollo/with-data'
 import redirect from '../../utils/apollo/redirect'
 import checkLoggedIn from '../../utils/apollo/check-logged-in'
-import LoginContent from '../../src/auth/login'
+import LoginContent from '/src/auth/login'
 
 export class Login extends BasePageComponent {
   /* istanbul ignore next */

--- a/pages/auth/login.js
+++ b/pages/auth/login.js
@@ -3,11 +3,11 @@ import {graphql, gql, withApollo, compose} from 'react-apollo'
 import cookie from 'cookie'
 
 import Layout from '/components/layouts'
-import {homeRoutes} from '../../utils/routes/routes-definitions'
+import {homeRoutes} from '/utils/routes/routes-definitions'
 
-import withData from '../../utils/apollo/with-data'
-import redirect from '../../utils/apollo/redirect'
-import checkLoggedIn from '../../utils/apollo/check-logged-in'
+import withData from '/utils/apollo/with-data'
+import redirect from '/utils/apollo/redirect'
+import checkLoggedIn from '/utils/apollo/check-logged-in'
 import LoginContent from '/src/auth/login'
 
 export class Login extends BasePageComponent {

--- a/pages/auth/login.js
+++ b/pages/auth/login.js
@@ -1,8 +1,8 @@
-import BasePageComponent from '../../components/base-page'
+import BasePageComponent from '/components/base-page'
 import {graphql, gql, withApollo, compose} from 'react-apollo'
 import cookie from 'cookie'
 
-import Layout from '../../components/layouts'
+import Layout from '/components/layouts'
 import {homeRoutes} from '../../utils/routes/routes-definitions'
 
 import withData from '../../utils/apollo/with-data'

--- a/pages/auth/sign-up.js
+++ b/pages/auth/sign-up.js
@@ -2,12 +2,12 @@ import BasePageComponent from '/components/base-page'
 import {graphql, gql, withApollo, compose} from 'react-apollo'
 import cookie from 'cookie'
 
-import {homeRoutes} from '../../utils/routes/routes-definitions'
+import {homeRoutes} from '/utils/routes/routes-definitions'
 
-import withData from '../../utils/apollo/with-data'
+import withData from '/utils/apollo/with-data'
 import Layout from '/components/layouts'
-import redirect from '../../utils/apollo/redirect'
-import checkLoggedIn from '../../utils/apollo/check-logged-in'
+import redirect from '/utils/apollo/redirect'
+import checkLoggedIn from '/utils/apollo/check-logged-in'
 import SignUpContent from '/src/auth/sign-up'
 
 export class SignUp extends BasePageComponent {

--- a/pages/auth/sign-up.js
+++ b/pages/auth/sign-up.js
@@ -8,7 +8,7 @@ import withData from '../../utils/apollo/with-data'
 import Layout from '/components/layouts'
 import redirect from '../../utils/apollo/redirect'
 import checkLoggedIn from '../../utils/apollo/check-logged-in'
-import SignUpContent from '../../src/auth/sign-up'
+import SignUpContent from '/src/auth/sign-up'
 
 export class SignUp extends BasePageComponent {
   /* istanbul ignore next */

--- a/pages/auth/sign-up.js
+++ b/pages/auth/sign-up.js
@@ -1,11 +1,11 @@
-import BasePageComponent from '../../components/base-page'
+import BasePageComponent from '/components/base-page'
 import {graphql, gql, withApollo, compose} from 'react-apollo'
 import cookie from 'cookie'
 
 import {homeRoutes} from '../../utils/routes/routes-definitions'
 
 import withData from '../../utils/apollo/with-data'
-import Layout from '../../components/layouts'
+import Layout from '/components/layouts'
 import redirect from '../../utils/apollo/redirect'
 import checkLoggedIn from '../../utils/apollo/check-logged-in'
 import SignUpContent from '../../src/auth/sign-up'

--- a/pages/projects/create.js
+++ b/pages/projects/create.js
@@ -1,6 +1,6 @@
-import BasePageComponent from '../../components/base-page'
-import withAuth from '../../components/with-auth'
-import Layout from '../../components/layouts'
+import BasePageComponent from '/components/base-page'
+import withAuth from '/components/with-auth'
+import Layout from '/components/layouts'
 import CreateContent from '../../src/projects/create'
 
 export class Create extends BasePageComponent {

--- a/pages/projects/create.js
+++ b/pages/projects/create.js
@@ -1,7 +1,7 @@
 import BasePageComponent from '/components/base-page'
 import withAuth from '/components/with-auth'
 import Layout from '/components/layouts'
-import CreateContent from '../../src/projects/create'
+import CreateContent from '/src/projects/create'
 
 export class Create extends BasePageComponent {
   render() {

--- a/pages/projects/details.js
+++ b/pages/projects/details.js
@@ -1,6 +1,6 @@
-import BasePageComponent from '../../components/base-page'
-import withAuth from '../../components/with-auth'
-import Layout from '../../components/layouts'
+import BasePageComponent from '/components/base-page'
+import withAuth from '/components/with-auth'
+import Layout from '/components/layouts'
 import DetailsContent from '../../src/projects/details'
 
 export class Details extends BasePageComponent {

--- a/pages/projects/details.js
+++ b/pages/projects/details.js
@@ -1,7 +1,7 @@
 import BasePageComponent from '/components/base-page'
 import withAuth from '/components/with-auth'
 import Layout from '/components/layouts'
-import DetailsContent from '../../src/projects/details'
+import DetailsContent from '/src/projects/details'
 
 export class Details extends BasePageComponent {
   render() {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import {mount} from 'enzyme'
-import {Link} from '../../utils/routes'
-import {projectRoutes} from '../../utils/routes/routes-definitions'
+import {Link} from '/utils/routes'
+import {projectRoutes} from '/utils/routes/routes-definitions'
 
 import Index from '../index'
 

--- a/src/auth/login/__tests__/login.js
+++ b/src/auth/login/__tests__/login.js
@@ -3,8 +3,8 @@ jest.mock('../../../../utils/routes')
 import {mount} from 'enzyme'
 
 import Login from '../'
-import {Link} from '../../../../utils/routes'
-import {authRoutes} from '../../../../utils/routes/routes-definitions'
+import {Link} from '/utils/routes'
+import {authRoutes} from '/utils/routes/routes-definitions'
 
 describe('src/auth/login', () => {
   it(`verifies ${Login.name} renders correctly`, () => {

--- a/src/auth/login/index.js
+++ b/src/auth/login/index.js
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types'
 import {Link} from '../../../utils/routes'
 import {authRoutes} from '../../../utils/routes/routes-definitions'
 
-import Input from '../../../components/input'
-import HeaderBar from '../../../components/header-bar'
-import Box from '../../../components/box'
-import Button from '../../../components/button'
+import Input from '/components/input'
+import HeaderBar from '/components/header-bar'
+import Box from '/components/box'
+import Button from '/components/button'
 
 const Login = ({signin}) => (
   <div>

--- a/src/auth/login/index.js
+++ b/src/auth/login/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
-import {Link} from '../../../utils/routes'
-import {authRoutes} from '../../../utils/routes/routes-definitions'
+import {Link} from '/utils/routes'
+import {authRoutes} from '/utils/routes/routes-definitions'
 
 import Input from '/components/input'
 import HeaderBar from '/components/header-bar'

--- a/src/auth/sign-up/__tests__/sign-up.js
+++ b/src/auth/sign-up/__tests__/sign-up.js
@@ -3,8 +3,8 @@ jest.mock('../../../../utils/routes')
 import {mount} from 'enzyme'
 
 import SignUp from '../'
-import {Link} from '../../../../utils/routes'
-import {authRoutes} from '../../../../utils/routes/routes-definitions'
+import {Link} from '/utils/routes'
+import {authRoutes} from '/utils/routes/routes-definitions'
 
 describe('src/auth/sign-up', () => {
   it(`verifies ${SignUp.name} renders correctly`, () => {

--- a/src/auth/sign-up/index.js
+++ b/src/auth/sign-up/index.js
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types'
 import {Link} from '../../../utils/routes'
 import {authRoutes} from '../../../utils/routes/routes-definitions'
 
-import Input from '../../../components/input'
-import HeaderBar from '../../../components/header-bar'
-import Box from '../../../components/box'
-import Button from '../../../components/button'
+import Input from '/components/input'
+import HeaderBar from '/components/header-bar'
+import Box from '/components/box'
+import Button from '/components/button'
 
 const SignUp = ({create}) => (
   <div>

--- a/src/auth/sign-up/index.js
+++ b/src/auth/sign-up/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
-import {Link} from '../../../utils/routes'
-import {authRoutes} from '../../../utils/routes/routes-definitions'
+import {Link} from '/utils/routes'
+import {authRoutes} from '/utils/routes/routes-definitions'
 
 import Input from '/components/input'
 import HeaderBar from '/components/header-bar'

--- a/src/projects/create/__tests__/index.js
+++ b/src/projects/create/__tests__/index.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import {mount} from 'enzyme'
-import CreateProjectForm from '../../../../components/project/create-form'
+import CreateProjectForm from '/components/project/create-form'
 
 import {Create} from '../index'
 

--- a/src/projects/create/index.js
+++ b/src/projects/create/index.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types'
 import {graphql, compose} from 'react-apollo'
 import {getProjectTypes, createProject} from './gq'
 
-import CreateProjectForm from '../../../components/project/create-form'
-import HeaderBar from '../../../components/header-bar'
-import Box from '../../../components/box'
+import CreateProjectForm from '/components/project/create-form'
+import HeaderBar from '/components/header-bar'
+import Box from '/components/box'
 
 export class Create extends React.Component {
   onSubmit = event => {

--- a/src/projects/details/__tests__/index.js
+++ b/src/projects/details/__tests__/index.js
@@ -4,7 +4,7 @@ import {mount} from 'enzyme'
 import {deepClone} from '../../../../utils/helpers'
 
 import {Loading, ProjectDetailsWrapper} from '../index'
-import ProjectDetails from '../../../../components/project/details'
+import ProjectDetails from '/components/project/details'
 
 const baseProps = {
   data: {

--- a/src/projects/details/__tests__/index.js
+++ b/src/projects/details/__tests__/index.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import {mount} from 'enzyme'
 
-import {deepClone} from '../../../../utils/helpers'
+import {deepClone} from '/utils/helpers'
 
 import {Loading, ProjectDetailsWrapper} from '../index'
 import ProjectDetails from '/components/project/details'

--- a/src/projects/details/index.js
+++ b/src/projects/details/index.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import {graphql} from 'react-apollo'
 import {getProject} from './gq'
 
-import ProjectDetails from '../../../components/project/details'
+import ProjectDetails from '/components/project/details'
 
 export const Loading = () => <p>Loading project...</p>
 

--- a/src/welcome/__tests__/index.js
+++ b/src/welcome/__tests__/index.js
@@ -2,7 +2,7 @@
 import {mount} from 'enzyme'
 
 import {Loading, WelcomeWrapper} from '../index'
-import ProjectList from '../../../components/project/list'
+import ProjectList from '/components/project/list'
 
 describe('src/welcome/index', () => {
   it(`verifies ${WelcomeWrapper.name} renders correctly while loading`, () => {

--- a/src/welcome/index.js
+++ b/src/welcome/index.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types'
 import {graphql} from 'react-apollo'
 import {getAllProjects} from './gq'
-import {Link} from '../../utils/routes'
-import {projectRoutes} from '../../utils/routes/routes-definitions'
+import {Link} from '/utils/routes'
+import {projectRoutes} from '/utils/routes/routes-definitions'
 
 import ProjectList from '/components/project/list'
 

--- a/src/welcome/index.js
+++ b/src/welcome/index.js
@@ -4,13 +4,13 @@ import {getAllProjects} from './gq'
 import {Link} from '../../utils/routes'
 import {projectRoutes} from '../../utils/routes/routes-definitions'
 
-import ProjectList from '../../components/project/list'
+import ProjectList from '/components/project/list'
 
-import Box from '../../components/box'
-import Search from '../../components/search'
-import Section from '../../components/section'
-import HeadBanner from '../../components/head-banner'
-import ContextButton from '../../components/context-button'
+import Box from '/components/box'
+import Search from '/components/search'
+import Section from '/components/section'
+import HeadBanner from '/components/head-banner'
+import ContextButton from '/components/context-button'
 
 export const Loading = () => <p>Loading projects...</p>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz#ea99f6121b4a8f065b4c71f85595db2714498807"
 
-"@std/esm@^0.9.2":
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.9.2.tgz#825dfadee6ba354536d275d6f7dbe1db542295b0"
+"@std/esm@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.10.0.tgz#5610607ec4c99acdb2104b263d3a3c406d06ef2d"
 
 "@storybook/addon-actions@^3.2.6":
   version "3.2.6"
@@ -865,6 +865,12 @@ babel-plugin-react-docgen@^1.6.0:
 babel-plugin-react-require@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz#2e4e7b4496b93a654a1c80042276de4e4eeb20e3"
+
+babel-plugin-root-import@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-root-import/-/babel-plugin-root-import-5.1.0.tgz#80ea1cd5945b463a5e3f7e204a69478c573e328c"
+  dependencies:
+    slash "^1.0.0"
 
 babel-plugin-styled-components@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
This introduces https://www.npmjs.com/package/babel-plugin-root-import.

Instead of import statements that look like this:

```
import Avatar from '../../../components/avatar'
```

We can now use `/` which points to the project root:

```
import Avatar from '/components/avatar'
```

This applies to any imports, not just components. You can start the import with `/` to indicate the project root.

**NOTE**
This does **not** work with `jest.mock()` calls. You still need to use relative paths when mocking imports.