### PR TITLE
Replace the image tag with img.

### DIFF
--- a/components/context-button/index.js
+++ b/components/context-button/index.js
@@ -16,7 +16,7 @@ const Icon = styled.div`
 const ContextButton = ({children}) => (
   <ContextButtonSC>
     <Icon>
-      <image src="../../static/mallet.png" />
+      <img src="../../static/mallet.png" alt="" />
     </Icon>
     {children}
   </ContextButtonSC>

--- a/components/header-bar/index.js
+++ b/components/header-bar/index.js
@@ -14,7 +14,7 @@ const HeaderBarButton = styled.div`
 const HeaderBar = ({children}) => (
   <HeaderBarSC>
     <HeaderBarButton>
-      <image src="../../static/back-arrow.svg" />
+      <img src="../../static/back-arrow.svg" alt="go back" />
     </HeaderBarButton>
     <h1>{children}</h1>
     <HeaderBarButton />

--- a/components/search/index.js
+++ b/components/search/index.js
@@ -29,7 +29,7 @@ const SearchInput = styled.input`
 const Search = () => (
   <SearchSC>
     <SearchIcon>
-      <image src="/static/search.png" alt="magnifying glass" />
+      <img src="/static/search.png" alt="magnifying glass" />
     </SearchIcon>
     <SearchInput placeholder="Search" type="text" />
   </SearchSC>

--- a/components/tab-bar/index.js
+++ b/components/tab-bar/index.js
@@ -25,7 +25,7 @@ const TabBar = () => (
   <TabBarSC>
     <TabBarButton>
       <SearchIcon>
-        <image src="../../static/search.svg" />
+        <img src="../../static/search.svg" alt="search" />
       </SearchIcon>
     </TabBarButton>
     <TabBarButton>


### PR DESCRIPTION
The `<image>` tag is obsolete: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/image.

The images loaded fine on the server (i.e. when the page was fully reloaded). However, on client-side rendering, the browser ignored the `<image>` tag and nothing rendered.