### PR TITLE
Parallelize ci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,19 +3,22 @@ job_defaults: &job_defaults
     - image: circleci/node:8.3.0
   working_directory: ~/repo
 
+steps_defaults: &steps_defaults
+  - checkout
+  - restore_cache:
+      keys:
+      - v1-dependencies-{{ checksum "package.json" }}
+      # fallback to using the latest cache if no exact match is found
+      - v1-dependencies-
+
+
 version: 2
 jobs:
   build:
     <<: *job_defaults
 
     steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+      <<: *steps_defaults
 
       - run: yarn install
 
@@ -24,17 +27,11 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-      - persist_to_workspace:
-          root: node_modules
-          paths:
-            - .
-
   lint:
     <<: *job_defaults
 
     steps:
-      - attach_workspace:
-          at: node_modules
+      <<: *steps_defaults
       
       - run:
           name: Lint
@@ -44,8 +41,7 @@ jobs:
     <<: *job_defaults
 
     steps:
-      - attach_workspace:
-          at: node_modules
+      <<: *steps_defaults
       
     #   - run:
     #       name: Before tests
@@ -61,8 +57,7 @@ jobs:
     <<: *job_defaults
 
     steps:
-      - attach_workspace:
-          at: node_modules
+      <<: *steps_defaults
       
       - run: echo "Deploy here, eventually"
         

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,15 +49,15 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
       
-    #   - run:
-    #       name: Before tests
-    #       command: ./node_modules/.bin/greenkeeper-lockfile-update
+      - run:
+          name: Before tests
+          command: ./node_modules/.bin/greenkeeper-lockfile-update
       - run:
           name: Run tests
           command: yarn test:coverage
-    #   - run:
-    #       name: After tests
-    #       command: ./node_modules/.bin/greenkeeper-lockfile-upload
+      - run:
+          name: After tests
+          command: ./node_modules/.bin/greenkeeper-lockfile-upload
 
   deploy:
     <<: *job_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,16 @@
-# Javascript Node CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
+job_defaults: &job_defaults
+  docker:
+    - image: circleci/node:8.3.0
+  working_directory: ~/repo
+
 version: 2
 jobs:
   build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/node:8.3.0
-      
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
-
-    working_directory: ~/repo
+    <<: *job_defaults
 
     steps:
       - checkout
 
-      # Download and cache dependencies
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "package.json" }}
@@ -32,13 +23,61 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-        
+
+      - persist_to_workspace:
+          root: node_modules
+          paths:
+            - .
+
+  lint:
+    <<: *job_defaults
+
+    steps:
+      - attach_workspace:
+          at: node_modules
+      
       - run:
-          name: Before tests
-          command: ./node_modules/.bin/greenkeeper-lockfile-update
+          name: Lint
+          command: yarn lint
+
+  test_coverage:
+    <<: *job_defaults
+
+    steps:
+      - attach_workspace:
+          at: node_modules
+      
+    #   - run:
+    #       name: Before tests
+    #       command: ./node_modules/.bin/greenkeeper-lockfile-update
       - run:
           name: Run tests
-          command: yarn test:ci
-      - run:
-          name: After tests
-          command: ./node_modules/.bin/greenkeeper-lockfile-upload
+          command: yarn test:coverage
+    #   - run:
+    #       name: After tests
+    #       command: ./node_modules/.bin/greenkeeper-lockfile-upload
+
+  deploy:
+    <<: *job_defaults
+
+    steps:
+      - attach_workspace:
+          at: node_modules
+      
+      - run: echo "Deploy here, eventually"
+        
+workflows:
+  version: 2
+  build_lint_test_coverage_deploy:
+    jobs:
+      - build
+      - lint:
+          requires:
+            - build
+      - test_coverage:
+          requires:
+            - build
+      - deploy:
+          requires:
+            - lint
+            - test_coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,22 +3,18 @@ job_defaults: &job_defaults
     - image: circleci/node:8.3.0
   working_directory: ~/repo
 
-steps_defaults: &steps_defaults
-  - checkout
-  - restore_cache:
-      keys:
-      - v1-dependencies-{{ checksum "package.json" }}
-      # fallback to using the latest cache if no exact match is found
-      - v1-dependencies-
-
-
 version: 2
 jobs:
   build:
     <<: *job_defaults
 
     steps:
-      <<: *steps_defaults
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
 
       - run: yarn install
 
@@ -31,7 +27,12 @@ jobs:
     <<: *job_defaults
 
     steps:
-      <<: *steps_defaults
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
       
       - run:
           name: Lint
@@ -41,7 +42,12 @@ jobs:
     <<: *job_defaults
 
     steps:
-      <<: *steps_defaults
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
       
     #   - run:
     #       name: Before tests
@@ -57,7 +63,12 @@ jobs:
     <<: *job_defaults
 
     steps:
-      <<: *steps_defaults
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
       
       - run: echo "Deploy here, eventually"
         


### PR DESCRIPTION
This enables workflows in CircleCI so that we can split a build into multiple, parallel and serial steps. With end to end tests coming soon, parallel build steps will keep build times at a minimum.

More importantly, we can visually track the progress of a build and continue a failed workflow from the place it failed. No need to re-run the entire test suite.

CircleCI docs: https://circleci.com/docs/2.0/workflows/

![image](https://user-images.githubusercontent.com/788827/31479275-ee566c5a-aeca-11e7-9880-6d747961b6b6.png)
